### PR TITLE
Implement event handling mechanism

### DIFF
--- a/apps/event_sourcing/.formatter.exs
+++ b/apps/event_sourcing/.formatter.exs
@@ -1,6 +1,9 @@
 locals_without_parens = [
   # EventSourcing.Dispatcher
-  dispatch: 2
+  dispatch: 2,
+  # EventSourcing.EventHandler
+  handle: 2,
+  handle: 3
 ]
 
 [

--- a/apps/event_sourcing/lib/event_sourcing/aggregates/aggregate.ex
+++ b/apps/event_sourcing/lib/event_sourcing/aggregates/aggregate.ex
@@ -1,6 +1,7 @@
 defmodule EventSourcing.Aggregates.Aggregate do
   use GenServer
 
+  alias EventSourcing.EventHandler
   alias EventSourcing.EventStore.AgentEventStore
 
   @registry EventSourcing.AggregateRegistry
@@ -35,6 +36,7 @@ defmodule EventSourcing.Aggregates.Aggregate do
     event = aggregate_mod.execute(aggregate, command)
     aggregate = aggregate_mod.apply(aggregate, event)
     store_event(store, aggregate, event)
+    EventHandler.dispatch(event, aggregate)
 
     {:reply, {event, aggregate}, %{state | aggregate: aggregate}}
   end

--- a/apps/event_sourcing/lib/event_sourcing/application.ex
+++ b/apps/event_sourcing/lib/event_sourcing/application.ex
@@ -6,6 +6,7 @@ defmodule EventSourcing.Application do
   def start(_type, _args) do
     children = [
       EventSourcing.Aggregates.AggregateSupervisor,
+      EventSourcing.EventHandler,
       {Registry, keys: :unique, name: EventSourcing.AggregateRegistry}
     ]
 

--- a/apps/event_sourcing/lib/event_sourcing/event_handler.ex
+++ b/apps/event_sourcing/lib/event_sourcing/event_handler.ex
@@ -1,0 +1,66 @@
+defmodule EventSourcing.EventHandler do
+  use GenServer
+
+  alias __MODULE__
+
+  defmacro __using__(_opts) do
+    {:ok, _} = Application.ensure_all_started(:event_sourcing)
+
+    quote do
+      import EventSourcing.EventHandler, only: [handle: 2, handle: 3]
+    end
+  end
+
+  defmacro handle(event, aggregate \\ quote(do: _), do: block) do
+    event_mod = get_event_mod(event)
+
+    quote location: :keep do
+      EventHandler.register_handler(unquote(event_mod), __MODULE__)
+
+      def handle_event(unquote(event), unquote(aggregate)) do
+        unquote(block)
+      end
+    end
+  end
+
+  defp get_event_mod({:=, _, [ast, _]}), do: get_event_mod(ast)
+  defp get_event_mod({:%, _, [{:__aliases__, _, _} = mod, _]}), do: mod
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def register_handler(event, handler) do
+    GenServer.call(__MODULE__, {:register_handler, event, handler})
+  end
+
+  def dispatch(event, aggregate) do
+    GenServer.cast(__MODULE__, {:dispatch, event, aggregate})
+  end
+
+  def init(_opts) do
+    state = %{
+      handlers: %{}
+    }
+
+    {:ok, state}
+  end
+
+  def handle_call({:register_handler, event, handler}, _from, state) do
+    state =
+      update_in(state.handlers[event], fn
+        nil -> [handler]
+        handlers -> [handler | handlers]
+      end)
+
+    {:reply, :ok, state}
+  end
+
+  def handle_cast({:dispatch, %mod{} = event, aggregate}, %{handlers: handlers} = state) do
+    handlers
+    |> Map.get(mod, [])
+    |> Enum.each(&spawn(&1, :handle_event, [event, aggregate]))
+
+    {:noreply, state}
+  end
+end

--- a/apps/event_sourcing/lib/event_sourcing/event_handler.ex
+++ b/apps/event_sourcing/lib/event_sourcing/event_handler.ex
@@ -14,7 +14,7 @@ defmodule EventSourcing.EventHandler do
   defmacro handle(event, aggregate \\ quote(do: _), do: block) do
     event_mod = get_event_mod(event)
 
-    quote location: :keep do
+    quote do
       EventHandler.register_handler(unquote(event_mod), __MODULE__)
 
       def handle_event(unquote(event), unquote(aggregate)) do

--- a/apps/event_sourcing/lib/event_sourcing/event_handler.ex
+++ b/apps/event_sourcing/lib/event_sourcing/event_handler.ex
@@ -1,8 +1,6 @@
 defmodule EventSourcing.EventHandler do
   use GenServer
 
-  alias __MODULE__
-
   defmacro __using__(_opts) do
     {:ok, _} = Application.ensure_all_started(:event_sourcing)
 
@@ -15,7 +13,7 @@ defmodule EventSourcing.EventHandler do
     event_mod = get_event_mod(event)
 
     quote do
-      EventHandler.register_handler(unquote(event_mod), __MODULE__)
+      EventSourcing.EventHandler.register_handler(unquote(event_mod), __MODULE__)
 
       def handle_event(unquote(event), unquote(aggregate)) do
         unquote(block)

--- a/apps/event_sourcing/test/event_sourcing/aggregates_test.exs
+++ b/apps/event_sourcing/test/event_sourcing/aggregates_test.exs
@@ -2,11 +2,13 @@ defmodule EventSourcing.AggregatesTest do
   use ExUnit.Case
 
   alias EventSourcing.Aggregates
+  alias EventSourcing.EventHandler
   alias Ecto.UUID
   alias EventSourcing.Counters.Aggregates.Counter
   alias EventSourcing.Counters.Commands.Increment
   alias EventSourcing.Counters.Events.Incremented
   alias EventSourcing.EventStore.EventStoreMock
+  alias EventSourcing.EventHandlerMock
 
   @registry EventSourcing.AggregateRegistry
 
@@ -62,9 +64,11 @@ defmodule EventSourcing.AggregatesTest do
     end
 
     test "dispatches events to event handlers", %{aggregate: aggregate, command: command} do
+      EventHandler.register_handler(Incremented, EventHandlerMock)
+
       {event, aggregate} = Aggregates.execute_command(aggregate, command)
 
-      assert_receive {:event_handler, ^event, ^aggregate}
+      assert_receive {:event_handler_called, ^event, ^aggregate}
     end
   end
 

--- a/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
+++ b/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
@@ -2,28 +2,17 @@ defmodule EventSourcing.EventHandlerTest do
   use ExUnit.Case
 
   alias EventSourcing.EventHandler
-
-  defmodule Incremented do
-    defstruct [:uuid, :counter_uuid, :test_pid]
-  end
-
-  defmodule Counter do
-    defstruct [:uuid, value: 0]
-  end
-
-  defmodule TestHandler do
-    def handle_event(%{test_pid: pid} = event, aggregate) do
-      send(pid, {:event_handler_called, event, aggregate})
-    end
-  end
+  alias EventSourcing.Counters.Aggregates.Counter
+  alias EventSourcing.Counters.Events.Incremented
+  alias EventSourcing.EventHandlerMock
 
   describe "handle/2,3 macro" do
     defmodule HandleTest do
       use EventSourcing.EventHandler
 
-      handle %Incremented{}, do: :ok
-
       handle %Incremented{}, %Counter{}, do: :ok
+
+      handle %Incremented{}, do: :ok
     end
 
     test "defines handle_event/2 function" do
@@ -38,7 +27,7 @@ defmodule EventSourcing.EventHandlerTest do
   setup do
     aggregate = %Counter{}
     event = %Incremented{test_pid: self()}
-    handler = TestHandler
+    handler = EventHandlerMock
 
     {:ok, aggregate: aggregate, event: event, handler: handler}
   end

--- a/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
+++ b/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
@@ -1,0 +1,71 @@
+defmodule EventSourcing.EventHandlerTest do
+  use ExUnit.Case
+
+  alias EventSourcing.EventHandler
+
+  defmodule Incremented do
+    defstruct [:uuid, :counter_uuid, :test_pid]
+  end
+
+  defmodule Counter do
+    defstruct [:uuid, value: 0]
+  end
+
+  defmodule TestHandler do
+    def handle_event(%{test_pid: pid} = event, aggregate) do
+      send(pid, {:event_handler_called, event, aggregate})
+    end
+  end
+
+  describe "handle/2,3 macro" do
+    defmodule HandleTest do
+      use EventSourcing.EventHandler
+
+      handle %Incremented{}, do: :ok
+
+      handle %Incremented{}, %Counter{}, do: :ok
+    end
+
+    test "defines handle_event/2 function" do
+      assert {:handle_event, 2} in HandleTest.__info__(:functions)
+    end
+
+    test "register event handlers" do
+      assert registered_handler?(Incremented, HandleTest)
+    end
+  end
+
+  setup do
+    aggregate = %Counter{}
+    event = %Incremented{test_pid: self()}
+    handler = TestHandler
+
+    {:ok, aggregate: aggregate, event: event, handler: handler}
+  end
+
+  describe "register_handler/2" do
+    test "adds module as event handler", %{event: %event{}} do
+      EventHandler.register_handler(event, TestHandler)
+
+      assert registered_handler?(event, TestHandler)
+    end
+  end
+
+  describe "dispatch/2" do
+    setup %{event: %event{}} do
+      EventHandler.register_handler(event, TestHandler)
+    end
+
+    test "sends event to all handlers", %{event: event, aggregate: aggregate} do
+      EventHandler.dispatch(event, aggregate)
+
+      assert_receive {:event_handler_called, ^event, ^aggregate}
+    end
+  end
+
+  defp registered_handler?(event, handler) do
+    %{handlers: handlers} = :sys.get_state(EventHandler)
+
+    handler in Map.get(handlers, event, [])
+  end
+end

--- a/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
+++ b/apps/event_sourcing/test/event_sourcing/event_handler_test.exs
@@ -44,16 +44,16 @@ defmodule EventSourcing.EventHandlerTest do
   end
 
   describe "register_handler/2" do
-    test "adds module as event handler", %{event: %event{}} do
-      EventHandler.register_handler(event, TestHandler)
+    test "adds module as event handler", %{event: %event_mod{}, handler: handler} do
+      EventHandler.register_handler(event_mod, handler)
 
-      assert registered_handler?(event, TestHandler)
+      assert registered_handler?(event_mod, handler)
     end
   end
 
   describe "dispatch/2" do
-    setup %{event: %event{}} do
-      EventHandler.register_handler(event, TestHandler)
+    setup %{event: %event_mod{}, handler: handler} do
+      EventHandler.register_handler(event_mod, handler)
     end
 
     test "sends event to all handlers", %{event: event, aggregate: aggregate} do

--- a/apps/event_sourcing/test/support/event_handler_mock.ex
+++ b/apps/event_sourcing/test/support/event_handler_mock.ex
@@ -1,0 +1,5 @@
+defmodule EventSourcing.EventHandlerMock do
+  def handle_event(%{test_pid: pid} = event, aggregate) do
+    send(pid, {:event_handler_called, event, aggregate})
+  end
+end


### PR DESCRIPTION
Currently implementation uses `GenServer` for storing registered handlers and dispatching events to them. Because `EventSourcing.EventHandler` is started as part of `Absence` supervision tree it's not available during compilation to register event handlers. Solutions I can think of:

1. Separate app inside umbrella project, started before Absence (similar to how `ExUnit` does)
2. Storing registered handlers inside `EventSourcing.EventHandler` module attribute, exposing them in `__registered_handlers__/0` function.
3. Changing implementation to use separate dispatcher module that has dispatching rules for events built into `dispatch/2` functions (similar to `EventSourcing.Dispatcher`.

Thoughts @dkusmierek ?

Resolves #9 